### PR TITLE
Add an alternative method for corridor delineation

### DIFF
--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -468,7 +468,10 @@ add_node_dist_sum <- function(net) {
         }) |> unlist())
 }
 
-# calculate weights; here sum
+# calculate weights; here Length + Distance
+# note that there are different ways to caclulate weights, for example
+# one can give more importance to Distance by Length + 2 * Distance
+# or one can use only Distance.
 calc_weights_sum <- function(net){
     net |>
         activate("edges") |>

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -430,7 +430,7 @@ st_write(
 
 ### Define some functions to calculate a different weight
 
-Here, the distance from the initial corridor edges is added to the edge length as "weight" of the network edges before looking for the shortest path. The additional cost would ideally try to keep the path as close as possible to the initial corridor edges.
+In this approach, the distance from the initial corridor edges is incorporated into the edge length as a "weight" before calculating the shortest path. This added cost encourages the path to stay as close as possible to the initial corridor. When comparing two edges of the same length, the edge closer to the initial corridor is preferred, as its nodes have smaller distances to the corridor. Conversely, when comparing edges with equal distances to the corridor, the one with the shorter length is selected. Therefore, the "weight" of an edge is determined by its length plus the sum of its distances from the corridor.
 
 ```{r}
 # add id to nodes

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -433,15 +433,6 @@ st_write(
 In this approach, the distance from the initial corridor edges is incorporated into the edge length as a "weight" before calculating the shortest path. This added cost encourages the path to stay as close as possible to the initial corridor. When comparing two edges of the same length, the edge closer to the initial corridor is preferred, as its nodes have smaller distances to the corridor. Conversely, when comparing edges with equal distances to the corridor, the one with the shorter length is selected. Therefore, the "weight" of an edge is determined by its length plus the sum of its distances from the corridor.
 
 ```{r}
-# add node distance to nodes
-add_node_dist <- function(net, buffer){
-    nodes <- getNodes(net)
-    distances <- st_distance(nodes, buffer, which = "Euclidean")
-    net |>
-        activate("nodes") |>
-        mutate(node_dist = distances)
-}
-
 # add edge_length to edges
 add_edge_length <- function(net){
     net |>
@@ -449,16 +440,12 @@ add_edge_length <- function(net){
         mutate(edge_length = edge_length())
 }
 
-# add sum of distances to each edge
-add_node_dist_sum <- function(net) {
+add_edge_dist <- function(net, buffer){
+    edges <- getEdges(net)
+    distances <- st_distance(edges, buffer, which = "Euclidean")
     net |>
         activate("edges") |>
-        mutate(nodes_dist_sum = map2(from, to, function(from_node, to_node) {
-        node_dist_values <- activate(net, "nodes") %>%
-            slice(c(from_node, to_node)) %>%
-            pull(node_dist)
-        return(sum(node_dist_values, na.rm = TRUE))
-        }) |> unlist())
+        mutate(edge_distance = distances)
 }
 
 # calculate weights; here Length + Distance
@@ -470,8 +457,8 @@ calc_weights_sum <- function(net, dist_weight){
         activate("edges") |>
         mutate(
             edge_length = set_units(edge_length, "m"),
-            nodes_dist_sum = set_units(nodes_dist_sum, "m"),
-            weight = (1. - dist_weight) * edge_length + dist_weight * nodes_dist_sum
+            edge_distance = set_units(edge_distance, "m"),
+            weight = (1. - dist_weight) * edge_length + dist_weight * edge_distance
             )
 }
 ```
@@ -483,9 +470,8 @@ dist_weight <- 0.5
 
 network <- trim(net, area, corridor_initial) |>
     clean() |>
-    add_node_dist(corridor_initial) |>
     add_edge_length() |>
-    add_node_dist_sum() |>
+    add_edge_dist(corridor_initial) |>
     calc_weights_sum(dist_weight) |>
     activate("nodes") |>
     filter(group_components() == 1)  # keep only the main connected component
@@ -500,9 +486,8 @@ dist_weight <- 0.5
 
 network <- trim(net, area, corridor_initial) |>
     clean() |>
-    add_node_dist(corridor_initial) |>
     add_edge_length() |>
-    add_node_dist_sum() |>
+    add_edge_dist(corridor_initial) |>
     calc_weights_sum(dist_weight) |>
     activate("nodes") |>
     filter(group_components() == 1)  # keep only the main connected component

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -433,13 +433,6 @@ st_write(
 In this approach, the distance from the initial corridor edges is incorporated into the edge length as a "weight" before calculating the shortest path. This added cost encourages the path to stay as close as possible to the initial corridor. When comparing two edges of the same length, the edge closer to the initial corridor is preferred, as its nodes have smaller distances to the corridor. Conversely, when comparing edges with equal distances to the corridor, the one with the shorter length is selected. Therefore, the "weight" of an edge is determined by its length plus the sum of its distances from the corridor.
 
 ```{r}
-# add id to nodes
-add_node_id <- function(net){
-    net |>
-        activate("nodes") |>
-        mutate(node_id = row_number())
-}
-
 # add node distance to nodes
 add_node_dist <- function(net, buffer){
     nodes <- getNodes(net)
@@ -489,7 +482,6 @@ area <- areas[1]
 
 network <- trim(net, area, corridor_initial) |>
     clean() |>
-    add_node_id() |>
     add_node_dist(corridor_initial) |>
     add_edge_length() |>
     add_node_dist_sum() |>
@@ -506,7 +498,6 @@ area <- areas[2]
 
 network <- trim(net, area, corridor_initial) |>
     clean() |>
-    add_node_id() |>
     add_node_dist(corridor_initial) |>
     add_edge_length() |>
     add_node_dist_sum() |>

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -160,7 +160,7 @@ leaflet() |>
 
 ```{r}
 # save the waterway geometries (string and polygon)
-st_write(c(waterway, waterbody), dsn = sprintf("data/generated/waterway_%s.gpkg", river_name), append = FALSE)
+st_write(c(waterway, waterbody), dsn = sprintf("../data/generated/waterway_%s.gpkg", river_name), append = FALSE)
 ```
 
 ## 2. Street network ----
@@ -218,8 +218,8 @@ leaflet() |>
 edges <- net |> st_as_sf("edges")
 nodes <- net |> st_as_sf("nodes")
 
-st_write(edges, dsn = sprintf("data/generated/street_network_edges_%s.gpkg", city_name), append = FALSE)
-st_write(nodes, dsn = sprintf("data/generated/street_network_nodes_%s.gpkg", city_name), append = FALSE)
+st_write(edges, dsn = sprintf("../data/generated/street_network_edges_%s.gpkg", city_name), append = FALSE)
+st_write(nodes, dsn = sprintf("../data/generated/street_network_nodes_%s.gpkg", city_name), append = FALSE)
 ```
 
 ## 3. Corridor edge delineation
@@ -415,7 +415,7 @@ st_write(
         st_union(corridor_edge_1),
         st_union(corridor_edge_2)
     ),
-    dsn = sprintf("data/generated/corridor_%s.gpkg", river_name),
+    dsn = sprintf("../data/generated/corridor_%s.gpkg", river_name),
     append=FALSE,
 )
 ```

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -463,15 +463,15 @@ add_node_dist_sum <- function(net) {
 
 # calculate weights; here Length + Distance
 # note that there are different ways to caclulate weights, for example
-# one can give more importance to Distance by Length + 2 * Distance
+# one can give more importance to Distance by 0.2 * Length + 0.8 * Distance
 # or one can use only Distance.
-calc_weights_sum <- function(net){
+calc_weights_sum <- function(net, dist_weight){
     net |>
         activate("edges") |>
         mutate(
             edge_length = set_units(edge_length, "m"),
             nodes_dist_sum = set_units(nodes_dist_sum, "m"),
-            weight = edge_length + nodes_dist_sum
+            weight = (1. - dist_weight) * edge_length + dist_weight * nodes_dist_sum
             )
 }
 ```
@@ -479,13 +479,14 @@ calc_weights_sum <- function(net){
 ```{r}
 # apply all function to the fisrt subset
 area <- areas[1]
+dist_weight <- 0.5
 
 network <- trim(net, area, corridor_initial) |>
     clean() |>
     add_node_dist(corridor_initial) |>
     add_edge_length() |>
     add_node_dist_sum() |>
-    calc_weights_sum() |>
+    calc_weights_sum(dist_weight) |>
     activate("nodes") |>
     filter(group_components() == 1)  # keep only the main connected component
 
@@ -495,13 +496,14 @@ corridor_edge_1_sum <- get_corridor_edge(network, area, vertices)
 ```{r}
 # apply all function to the second subset
 area <- areas[2]
+dist_weight <- 0.5
 
 network <- trim(net, area, corridor_initial) |>
     clean() |>
     add_node_dist(corridor_initial) |>
     add_edge_length() |>
     add_node_dist_sum() |>
-    calc_weights_sum() |>
+    calc_weights_sum(dist_weight) |>
     activate("nodes") |>
     filter(group_components() == 1)  # keep only the main connected component
 

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -15,6 +15,7 @@ library("purrr")
 library("sf")
 library("sfnetworks")
 library("tidygraph")
+library("units")
 ```
 
 In this notebooks we explore how to delineate river corridor edges using Bucharest as the study area. We focus on one of the rivers and use a specific projected CRS for the analysis. Also, we make sure that we include a given area around the city boundaries.
@@ -300,7 +301,8 @@ clean <- function(net){
 cleaned <- clean(trimmed)
 ```
 
-We calculate the weights (= distances) of the edges, will be used to determine the shortest paths between the two vertices
+### calculate short path
+We calculate the weights (= length) of the edges, will be used to determine the shortest paths between the two vertices
 
 ```{r}
 calc_weights <- function(net){
@@ -416,4 +418,101 @@ st_write(
     dsn = sprintf("data/generated/corridor_%s.gpkg", river_name),
     append=FALSE,
 )
+```
+
+### Define some functions to calculate a different weight
+
+Here, the distance from the initial corridor edges is added to the edge length as "weight" of the network edges before looking for the shortest path. The additional cost would ideally try to keep the path as close as possible to the initial corridor edges.
+
+```{r}
+# add id to nodes
+add_node_id <- function(net){
+    net |>
+        activate("nodes") |>
+        mutate(node_id = row_number())
+}
+
+# add node distance to nodes
+add_node_dist <- function(net){
+    nodes <- getNodes(net)
+    distances <- st_distance(nodes, corridor_initial, which = "Euclidean")
+    net |>
+        activate("nodes") |>
+        mutate(node_dist = distances)
+}
+
+# add edge_length to edges
+add_edge_length <- function(net){
+    net |>
+        activate("edges") |>
+        mutate(edge_length = edge_length())
+}
+
+# add sum of distances to each edge
+add_node_dist_sum <- function(net) {
+    net |>
+        activate("edges") |>
+        mutate(nodes_dist_sum = map2(from, to, function(from_node, to_node) {
+        node_dist_values <- activate(net, "nodes") %>%
+            slice(c(from_node, to_node)) %>%
+            pull(node_dist)
+        return(sum(node_dist_values, na.rm = TRUE))
+        }) |> unlist())
+}
+
+# calculate weights; here sum
+calc_weights_sum <- function(net){
+    net |>
+        activate("edges") |>
+        mutate(
+            edge_length = set_units(edge_length, "m"),
+            nodes_dist_sum = set_units(nodes_dist_sum, "m"),
+            weight = edge_length + nodes_dist_sum
+            )
+}
+```
+
+```{r}
+# apply all function for fisrt subset
+area <- areas[1]
+
+network <- trim(net, area, corridor_initial) |>
+    clean() |>
+    add_node_id() |>
+    add_node_dist() |>
+    add_edge_length() |>
+    add_node_dist_sum() |>
+    calc_weights_sum() |>
+    activate("nodes") |>
+    filter(group_components() == 1)  # keep only the main connected component
+
+corridor_edge_1_sum <- get_corridor_edge(network, area, vertices)
+```
+
+```{r}
+# apply all function for second subset
+area <- areas[2]
+
+network <- trim(net, area, corridor_initial) |>
+    clean() |>
+    add_node_id() |>
+    add_node_dist() |>
+    add_edge_length() |>
+    add_node_dist_sum() |>
+    calc_weights_sum() |>
+    activate("nodes") |>
+    filter(group_components() == 1)  # keep only the main connected component
+
+corridor_edge_2_sum <- get_corridor_edge(network, area, vertices)
+```
+
+```{r}
+# comparison
+leaflet() |>
+    addTiles() |>
+    addPolygons(data = getGeomLatLon(corridor_initial), color = "blue") |>
+    addPolylines(data = corridor_edge_1_sum |> getGeomLatLon(), color = "red")|>
+    addPolylines(data = corridor_edge_2_sum |> getGeomLatLon(), color = "red")|>
+    addPolylines(data = corridor_edge_1 |> getGeomLatLon(), color = "blue")|>
+    addPolylines(data = corridor_edge_2 |> getGeomLatLon(), color = "blue")
 ```

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -441,9 +441,9 @@ add_node_id <- function(net){
 }
 
 # add node distance to nodes
-add_node_dist <- function(net){
+add_node_dist <- function(net, buffer){
     nodes <- getNodes(net)
-    distances <- st_distance(nodes, corridor_initial, which = "Euclidean")
+    distances <- st_distance(nodes, buffer, which = "Euclidean")
     net |>
         activate("nodes") |>
         mutate(node_dist = distances)
@@ -487,7 +487,7 @@ area <- areas[1]
 network <- trim(net, area, corridor_initial) |>
     clean() |>
     add_node_id() |>
-    add_node_dist() |>
+    add_node_dist(corridor_initial) |>
     add_edge_length() |>
     add_node_dist_sum() |>
     calc_weights_sum() |>
@@ -504,7 +504,7 @@ area <- areas[2]
 network <- trim(net, area, corridor_initial) |>
     clean() |>
     add_node_id() |>
-    add_node_dist() |>
+    add_node_dist(corridor_initial) |>
     add_edge_length() |>
     add_node_dist_sum() |>
     calc_weights_sum() |>

--- a/notebooks/corridor/corridor_bucharest.qmd
+++ b/notebooks/corridor/corridor_bucharest.qmd
@@ -21,6 +21,11 @@ library("units")
 In this notebooks we explore how to delineate river corridor edges using Bucharest as the study area. We focus on one of the rivers and use a specific projected CRS for the analysis. Also, we make sure that we include a given area around the city boundaries.
 
 ```{r}
+# define a directory to store some outputs
+output_dir = "."
+```
+
+```{r}
 city_name <- "Bucharest"
 river_name <- "Dâmbovița"
 epsg_code <- 32635  # UTM zone 35N
@@ -92,7 +97,7 @@ waterway <- waterways$osm_multilines |>
     st_geometry() |>
     st_intersection(st_buffer(bbox, bbox_buffer + 1000))
 
-# st_write(waterway, "../data/generated/waterway.gpkg")
+# st_write(waterway, sprintf("%s/waterway.gpkg", output_dir))
 ```
 
 ```{r}
@@ -160,7 +165,10 @@ leaflet() |>
 
 ```{r}
 # save the waterway geometries (string and polygon)
-st_write(c(waterway, waterbody), dsn = sprintf("../data/generated/waterway_%s.gpkg", river_name), append = FALSE)
+st_write(
+    c(waterway, waterbody),
+    dsn = sprintf("%s/waterway_%s.gpkg", output_dir, river_name), append = FALSE
+    )
 ```
 
 ## 2. Street network ----
@@ -191,7 +199,7 @@ highways_lines <- highways$osm_lines |>
     bind_rows(poly_to_lines)
     # \> bind_rows(routes)
 
-# st_write(highways_lines, "../data/generated/streets.gpkg")
+# st_write(highways_lines, sprintf("%s/streets.gpkg", output_dir))
 ```
 
 ```{r}
@@ -218,8 +226,8 @@ leaflet() |>
 edges <- net |> st_as_sf("edges")
 nodes <- net |> st_as_sf("nodes")
 
-st_write(edges, dsn = sprintf("../data/generated/street_network_edges_%s.gpkg", city_name), append = FALSE)
-st_write(nodes, dsn = sprintf("../data/generated/street_network_nodes_%s.gpkg", city_name), append = FALSE)
+st_write(edges, dsn = sprintf("%s/street_network_edges_%s.gpkg", output_dir, city_name), append = FALSE)
+st_write(nodes, dsn = sprintf("%s/street_network_nodes_%s.gpkg", output_dir, city_name), append = FALSE)
 ```
 
 ## 3. Corridor edge delineation
@@ -415,7 +423,7 @@ st_write(
         st_union(corridor_edge_1),
         st_union(corridor_edge_2)
     ),
-    dsn = sprintf("../data/generated/corridor_%s.gpkg", river_name),
+    dsn = sprintf("%s/corridor_%s.gpkg", output_dir, river_name),
     append=FALSE,
 )
 ```
@@ -473,7 +481,7 @@ calc_weights_sum <- function(net){
 ```
 
 ```{r}
-# apply all function for fisrt subset
+# apply all function to the fisrt subset
 area <- areas[1]
 
 network <- trim(net, area, corridor_initial) |>
@@ -490,7 +498,7 @@ corridor_edge_1_sum <- get_corridor_edge(network, area, vertices)
 ```
 
 ```{r}
-# apply all function for second subset
+# apply all function to the second subset
 area <- areas[2]
 
 network <- trim(net, area, corridor_initial) |>


### PR DESCRIPTION
closes #8

This PR includes the lateral distance of edges (sum of its node distances) from the initial corridor guess in defining the shortest path. 