### PR TITLE
Include rail network in the corridor delineation

### DIFF
--- a/notebooks/corridor/clean-network_bucharest.qmd
+++ b/notebooks/corridor/clean-network_bucharest.qmd
@@ -1,0 +1,250 @@
+---
+title: "Network cleaning"
+format: html
+---
+
+```{r}
+#| label: setup
+#| message: false
+
+library("dplyr")
+library("here")
+library("leaflet")
+library("sf")
+library("sfheaders")
+library("sfnetworks")
+library("tibble")
+library("tidygraph")
+```
+
+In this notebook we setup the network for the city of Bucharest that will be used for the corridor delineation. This network will contains both streets and railways from OSM.
+
+```{r}
+city_name <- "Bucharest"
+
+data_dir <- here("data/generated")
+```
+
+We define a utility function for visualization:
+
+```{r}
+# get geometry in lat/lon (WGS84)
+get_geom_latlon <- function(x) st_transform(x, 4326) |> st_geometry()
+```
+
+## 1. Input data ----
+
+We load the OSM data that we have previously downloaded (see notebook [`download-OSM-data_bucharest.qmd`](./download-OSM-data_bucharest.qmd)):
+
+```{r}
+load_data <- function(dir, handle, name) {
+    file_name <- sprintf("%s/%s_%s.gpkg", dir, handle, name)
+    st_read(file_name, quiet = TRUE)
+}
+
+highways <- load_data(data_dir, "highways", city_name)
+railways <- load_data(data_dir, "railways", city_name)
+```
+
+Visualize input data:
+
+```{r}
+leaflet() |>
+    addTiles() |>
+    addPolylines(data = highways |> get_geom_latlon(), color = "black", group = "highways") |>
+    addPolylines(data = railways |> get_geom_latlon(), color = "red", group = "railways") |>
+    addLayersControl(overlayGroups = c("highways", "railways"))
+```
+
+## 2. Setting up the network ----
+
+We want to create a joint network that includes both railways and highways:
+
+```{r}
+network <- bind_rows(highways, railways) |>
+  as_sfnetwork(directed = FALSE)
+```
+
+We want to flatten the two networks and add nodes at all intersections between edges. To this end, we first identify the unique intersections between edges:
+
+```{r}
+# Determine intersection points between crossing edges
+edges_cross <- network |>
+  activate("edges") |>
+  mutate(id = 1:n()) |>  # add ID to ease replacement later on
+  filter(edge_crosses(.E())) |>
+  st_as_sf("edges")
+
+pts_intersect <- st_intersection(edges_cross) |>
+  # some intersections might be multipoints, cast them to points
+  st_collection_extract("POINT") |> sf_cast(to = "POINT")
+
+# Drop duplicates
+pts_intersect_agg <- aggregate(
+  pts_intersect,
+  by = st_geometry(pts_intersect),
+  FUN = unique,
+  drop = TRUE
+)
+pts_intersect_unique <- pts_intersect_agg |> distinct()
+```
+
+We then want to inject these points within the edge geometries (linestrings), so that we can then use `sfnetworks::to_spatial_subdivision` to raise them as network nodes. Note that `sfnetworks::st_network_blend` cannot be used for this purpose, because this function only adds external points to one edge (the closest one).
+
+We define the functions that we use to inject points to the edge geometries:
+
+```{r}
+# calculate Euclidean distance between (x1, y1) and (x2, y2)
+distance <- function(x1, y1, x2, y2){
+  sqrt((x2 - x1)^2 + (y2 - y1)^2)
+}
+
+# `edge_pts` data.frame with all the edge points from the network
+# `point` a point to be added to an edge
+# `line_id` the id of the edge which the point should be added to
+insert_intersection <- function(edge_pts, point, line_id){
+  line_pts <- subset(edge_pts, linestring_id==line_id)
+  pt_x <- point[[1]]
+  pt_y <- point[[2]]
+  is_point_in_line <- nrow(subset(line_pts, x==pt_x & y==pt_y)) >= 1
+  if (!is_point_in_line){
+    startpoint <- subset(line_pts, is_startpoint==TRUE)
+    kk <- as.numeric(rownames(startpoint))
+    w_break <- FALSE
+    while(!w_break){
+      # consider the line segments a - b.
+      # x is a valid intersection if the following condition is true:
+      # distance(a, b) == distance(a, x) + distance(x, b)
+      pt_a_x <- edge_pts[kk,]$x
+      pt_a_y <- edge_pts[kk,]$y
+      pt_b_x <- edge_pts[kk+1,]$x
+      pt_b_y <- edge_pts[kk+1,]$y
+
+      d_ab <- distance(pt_a_x, pt_a_y, pt_b_x, pt_b_y)
+      d_ax <- distance(pt_a_x, pt_a_y, pt_x, pt_y)
+      d_bx <- distance(pt_b_x, pt_b_y, pt_x, pt_y)
+      is_intersection <- near(d_ab, d_ax + d_bx, tol = 1.e-3)
+      if (is_intersection){
+        insertion <- tibble_row(
+          sfg_id = line_id,
+          linestring_id = line_id,
+          x = pt_x,
+          y = pt_y,
+          is_startpoint = FALSE,
+          is_endpoint = FALSE
+        )
+        edge_pts <- add_row(edge_pts, insertion, .after = kk)
+        w_break <- TRUE
+      } else {
+        if (edge_pts[kk+1,]$is_endpoint){
+          warning("point is not added to the edge df.")
+          w_break <- TRUE
+        }
+      }
+      kk <- kk+1
+    }
+  }
+  edge_pts
+}
+```
+
+Such injection takes place in the following few steps:
+
+```{r}
+# Convert edge table to data.frame and add info on boundary points
+edge_pts <- sf_to_df(edges_cross)
+edge_idxs <- edge_pts$linestring_id
+edge_pts$is_startpoint <- !duplicated(edge_idxs)
+edge_pts$is_endpoint <- !duplicated(edge_idxs, fromLast = TRUE)
+```
+```{r}
+# Loop over all points, add them to the edge table
+for (i in 1:nrow(pts_intersect_unique)){
+  point <- pts_intersect_unique$geometry[[i]]
+  intersecting_edges <- unique(unlist(pts_intersect_unique$origins[i]))
+  for (edge_id in intersecting_edges){
+    edge_pts <- insert_intersection(edge_pts, point, edge_id)
+  }
+}
+```
+```{r}
+# Convert back edge table to sfc object
+edges_cross_new <- sfc_linestring(edge_pts, linestring_id = "id", x = "x", y = "y")
+st_crs(edges_cross_new) <- st_crs(edges_cross)
+```
+
+```{r}
+# Update the network with the new edge geometries
+nodes <- network |> st_as_sf("nodes")
+edges <- network |> st_as_sf("edges")
+edges[edges_cross$id,] <- edges[edges_cross$id,] |> st_set_geometry(edges_cross_new)
+network_new <- sfnetwork(
+  nodes = nodes,
+  edges = edges,
+  directed = FALSE,
+  force = TRUE,  # skip checks
+)
+```
+
+## 3. Network cleaning ----
+
+We now perform standard cleaning tasks on the network:
+
+```{r}
+# Simplify the graph, removing loops and double-edge connections
+# https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#simplify-network
+simplify <- function(net){
+    net|>
+        activate("edges") |>
+        # reorder the edges so that the shortest is kept
+        arrange(edge_length()) |>
+        filter(!edge_is_multiple()) |>
+        filter(!edge_is_loop())
+}
+
+clean <- function(net){
+    net |>
+        # subdivide edges by adding missing nodes
+        # https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#subdivide-edges
+        convert(to_spatial_subdivision, .clean = TRUE) |>
+        # remove pseudo-nodes
+        # https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#smooth-pseudo-nodes
+        convert(to_spatial_smooth, .clean = TRUE) |>
+        # run simplification steps
+        simplify() |>
+        # keep only the main connected component of the network
+        activate("nodes") |>
+        filter(group_components() == 1)
+}
+
+network_cleaned <- clean(network_new)
+```
+
+Visualize cleaned network:
+
+```{r}
+leaflet() |>
+    addTiles() |>
+    addPolylines(data = network_cleaned |> activate("edges") |> get_geom_latlon(), color = "black") |>
+    addCircles(data = network_cleaned |> activate("nodes") |> get_geom_latlon(), color = "red")
+```
+
+# 4. Network export ----
+
+We saved the edges and nodes of the cleaned network:
+
+```{r}
+st_write(
+    network_cleaned |> st_as_sf("edges"),
+    dsn = sprintf("%s/network_edges_%s.gpkg", data_dir, city_name),
+    append = FALSE,
+    quiet = TRUE,
+)
+st_write(
+    network_cleaned |> st_as_sf("nodes"),
+    dsn = sprintf("%s/network_nodes_%s.gpkg", data_dir, city_name),
+    append = FALSE,
+    quiet = TRUE,
+)
+```
+

--- a/notebooks/corridor/corridor_bucharest_river-valley.qmd
+++ b/notebooks/corridor/corridor_bucharest_river-valley.qmd
@@ -26,15 +26,11 @@ river_name <- "Dâmbovița"
 data_dir <- here("data/generated")
 ```
 
-We define a couple of utility functions:
+We define a utility function for visualization:
 
 ```{r}
 # get geometry in lat/lon (WGS84)
 get_geom_latlon <- function(x) st_transform(x, 4326) |> st_geometry()
-
-# extract nodes and edges from a sfnetwork object
-get_nodes <- function(net) net |> activate("nodes") |> st_geometry()
-get_edges <- function(net) net |> activate("edges") |> st_geometry()
 ```
 
 
@@ -50,8 +46,6 @@ load_data <- function(dir, handle, name) {
 
 city_boundary <- load_data(data_dir, "city_boundary", city_name)
 water <- load_data(data_dir, "waterway", river_name)
-highways <- load_data(data_dir, "highways", city_name)
-railways <- load_data(data_dir, "railways", city_name)
 
 # the "water" object includes the waterway (linestring)
 # and the water body (polygon) geometrues
@@ -59,7 +53,16 @@ waterway <- water[1,] |> st_geometry()
 waterbody <- water[2,] |> st_geometry()
 ```
 
-We also load in the river valley edges, as computed from the DEM (see notebook [`river-valley_bucharest.qmd`](../river-valley/river-valley_bucharest.qmd)):
+We also load in the nodes and edges of the pre-clean network, obtained by merging the highway and railway networks (see notebook [`clean-network_bucharest.qmd`](./clean-network_bucharest.qmd)):
+
+```{r}
+nodes <- load_data(data_dir, "network_nodes", city_name)
+edges <- load_data(data_dir, "network_edges", city_name)
+
+network <- sfnetwork(nodes = nodes, edges = edges, directed = FALSE, force = TRUE)
+```
+
+Finally, we load in the river valley edges, as computed from the DEM (see notebook [`river-valley_bucharest.qmd`](../river-valley/river-valley_bucharest.qmd)):
 
 ```{r}
 valley <- load_data(data_dir, "valley", river_name)
@@ -74,63 +77,12 @@ leaflet() |>
     addPolygons(data = valley |> get_geom_latlon(), color = "orange", group = "valley") |>
     addPolylines(data = waterway |> get_geom_latlon(), color = "blue", group = "water") |>
     addPolygons(data = waterbody |> get_geom_latlon(), color = "cyan", group = "water") |>
-    addPolylines(data = highways |> get_geom_latlon(), color = "black", group = "highways") |>
-    addPolylines(data = railways |> get_geom_latlon(), color = "red", group = "railways") |>
-    addLayersControl(overlayGroups = c("city", "valley", "water", "highways", "railways"))
+    addPolylines(data = network |> activate("edges") |> get_geom_latlon(), color = "black", group = "network") |>
+    addCircles(data = network |> activate("nodes") |> get_geom_latlon(), color = "red", group = "network") |>
+    addLayersControl(overlayGroups = c("city", "valley", "water", "network"))
 ```
 
-## 2. Street network ----
-
-We use the highway geometries to create the street network using `sfnetworks`:
-
-```{r}
-network <- highways |>
-    as_sfnetwork(directed = FALSE)
-```
-
-We perform standard cleaning tasks on the network:
-
-```{r}
-# Simplify the graph, removing loops and double-edge connections
-# https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#simplify-network
-simplify <- function(net){
-    net|>
-        activate("edges") |>
-        # reorder the edges so that the shortest is kept
-        arrange(edge_length()) |>
-        filter(!edge_is_multiple()) |>
-        filter(!edge_is_loop())
-}
-
-clean <- function(net){
-    net |>
-        # subdivide edges by adding missing nodes
-        # https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#subdivide-edges
-        convert(to_spatial_subdivision, .clean = TRUE) |>
-        # remove pseudo-nodes
-        # https://luukvdmeer.github.io/sfnetworks/articles/sfn02_preprocess_clean.html#smooth-pseudo-nodes
-        convert(to_spatial_smooth, .clean = TRUE) |>
-        # run simplification steps
-        simplify() |>
-        # keep only the main connected component of the network
-        activate("nodes") |>
-        filter(group_components() == 1)
-}
-
-network_cleaned <- clean(network)
-```
-
-Visualize cleaned network:
-
-```{r}
-leaflet() |>
-    addTiles() |>
-    addPolylines(data = network_cleaned |> get_edges() |> get_geom_latlon(), color = "black") |>
-    addCircles(data = network_cleaned |> get_nodes() |> get_geom_latlon(), color = "red")
-```
-
-
-## 3. Corridor edge delineation ----
+## 2. Corridor edge delineation ----
 
 We carry out the delineation of the river corridor in few steps.
 
@@ -165,7 +117,7 @@ bbox_polygon <- city_boundary |>
 river_sides <- split_river_sides(bbox_polygon, waterway)
 
 # label nodes with side of the river they fall on
-network_classified <- network_cleaned |>
+network_classified <- network |>
     activate("nodes") |>
     mutate(side_1 = node_intersects(river_sides[1,])) |>
     mutate(side_2 = node_intersects(river_sides[2,]))
@@ -188,7 +140,7 @@ get_nearest_nodes <- function(net, target_points, side){
     nodes <- net |>
         activate("nodes") |>
         filter(get({{side}})) |>
-        get_nodes()
+        st_geometry()
     idx <- st_nearest_feature(target_points, nodes)
     nodes[idx]
 }
@@ -223,7 +175,7 @@ The weight assigned to each edge is a linear combination of these components - c
 # add edge weights to the network, accounting for the combined effect of the
 # edge length, distance from a give geometry, intersection with a buffer region
 add_weights <- function(net, geom, buffer){
-    edges <- get_edges(net)
+    edges <- net |> st_as_sf("edges")
     distances <- st_distance(edges, geom, which = "Euclidean")
     # the following is very slow, use approximate (faster) approach
     # is_inside <- edges |>
@@ -272,7 +224,7 @@ get_corridor_edge <- function(net, end_points, weight_name = "weight"){
         type = "shortest",
     )
 
-    edges <- get_edges(net)
+    edges <- net |> st_as_sf("edges") |> st_geometry()
     edge_path <- paths |> pull(edge_paths) |> unlist()
     edges[edge_path]
 }
@@ -288,8 +240,8 @@ We visualize the computed corridor edges:
 ```{r}
 leaflet() |>
     addTiles() |>
-    addPolylines(data = network_split |> get_edges() |> get_geom_latlon(), color = "black") |>
-    addCircles(data = network_split |> get_nodes() |> get_geom_latlon(), color = "red") |>
+    addPolylines(data = network_split |> activate("edges") |> get_geom_latlon(), color = "black") |>
+    addCircles(data = network_split |> activate("nodes") |> get_geom_latlon(), color = "red") |>
     addPolylines(data = edge_side_1 |> get_geom_latlon(), color = "blue") |>
     addPolylines(data = edge_side_2 |> get_geom_latlon(), color = "green") |>
     addCircles(data = end_points_side_1 |> get_geom_latlon(), radius = 50, color = "blue") |>


### PR DESCRIPTION
Adding the functionality introduced in #18 to integrate the rail system to the network. Result looks quite good, with a part of the corridor edge running on the rail network, as expected (see Northwestern side of the river).

In practical terms, I have moved all the network cleaning part to a separate notebook. 

![Screenshot 2024-10-01 at 16 26 04](https://github.com/user-attachments/assets/185c23e6-ba27-4ea9-b62f-6582bdb38173)
