### PR TITLE
Fix deviations in coridor edge delineation

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,0 @@
-source("renv/activate.R")

--- a/notebooks/corridor/corridor_bucharest_river-valley.qmd
+++ b/notebooks/corridor/corridor_bucharest_river-valley.qmd
@@ -239,23 +239,6 @@ corridor_edge_1 <- get_corridor_edge(network_split, end_points_side_1,  weight_n
 corridor_edge_2 <- get_corridor_edge(network_split, end_points_side_2,  weight_name = "weight_side_2")
 ```
 
-### 3.4 Visualize
-
-We visualize the computed corridor edges:
-
-```{r}
-leaflet() |>
-    addTiles() |>
-    addPolylines(data = network_split |> activate("edges") |> get_geom_latlon(), color = "black") |>
-    addCircles(data = network_split |> activate("nodes") |> get_geom_latlon(), color = "red") |>
-    addPolylines(data = edge_side_1 |> get_geom_latlon(), color = "blue") |>
-    addPolylines(data = edge_side_2 |> get_geom_latlon(), color = "green") |>
-    addCircles(data = end_points_side_1 |> get_geom_latlon(), radius = 50, color = "blue") |>
-    addCircles(data = end_points_side_2 |> get_geom_latlon(), radius = 50, color = "green") |>
-    addPolylines(data = corridor_edge_1 |> get_geom_latlon(), color = "blue", weight = 10) |>
-    addPolylines(data = corridor_edge_2 |> get_geom_latlon(), color = "green", weight = 10)
-```
-
 ### Fix deviations
 
 ```{r}
@@ -265,7 +248,7 @@ corridor_edge_2 <- corridor_edge_2 |> st_union()
 names(corridor_edge_1) <- "side_1"
 names(corridor_edge_2) <- "side_2"
 
-network_weights_2 <- network_weights |> 
+network_weights_2 <- network_classified |> 
     add_weights(corridor_edge_1) |> 
     add_weights(corridor_edge_2)
 
@@ -277,6 +260,44 @@ network_split_2 <- network_weights_2  |>
 
 corridor_edge_1_nodev <- get_corridor_edge(network_split_2, end_points_side_1,  weight_name = "weight_side_1")
 corridor_edge_2_nodev <- get_corridor_edge(network_split_2, end_points_side_2,  weight_name = "weight_side_2")
+```
+
+```{r}
+corridor_edge_1_nodev <- corridor_edge_1_nodev |> st_union()
+corridor_edge_2_nodev <- corridor_edge_2_nodev |> st_union()
+
+names(corridor_edge_1_nodev) <- "side_1"
+names(corridor_edge_2_nodev) <- "side_2"
+
+network_weights_3 <- network_classified |> 
+    add_weights(corridor_edge_1_nodev) |> 
+    add_weights(corridor_edge_2_nodev)
+
+network_split_3 <- network_weights_3  |>
+    activate("edges") |>
+    st_filter(waterway, .predicate = not_intersects) |>
+    activate("nodes") |>
+    filter(!node_is_isolated())
+
+corridor_edge_1_nodev_2 <- get_corridor_edge(network_split_3, end_points_side_1,  weight_name = "weight_side_1")
+corridor_edge_2_nodev_2 <- get_corridor_edge(network_split_3, end_points_side_2,  weight_name = "weight_side_2")
+```
+
+### 3.4 Visualize
+
+We visualize the computed corridor edges:
+
+```{r}
+leaflet() |>
+    addTiles() |>
+    addPolylines(data = network_split_2 |> activate("edges") |> get_geom_latlon(), color = "black") |>
+    addCircles(data = network_split_2 |> activate("nodes") |> get_geom_latlon(), color = "red") |>
+    addPolylines(data = edge_side_1 |> get_geom_latlon(), color = "blue") |>
+    addPolylines(data = edge_side_2 |> get_geom_latlon(), color = "green") |>
+    addCircles(data = end_points_side_1 |> get_geom_latlon(), radius = 50, color = "blue") |>
+    addCircles(data = end_points_side_2 |> get_geom_latlon(), radius = 50, color = "green") |>
+    addPolylines(data = corridor_edge_1_nodev |> get_geom_latlon(), color = "blue", weight = 10) |>
+    addPolylines(data = corridor_edge_2_nodev |> get_geom_latlon(), color = "green", weight = 10)
 ```
 
 

--- a/notebooks/corridor/corridor_bucharest_river-valley.qmd
+++ b/notebooks/corridor/corridor_bucharest_river-valley.qmd
@@ -174,23 +174,29 @@ The weight assigned to each edge is a linear combination of these components - c
 ```{r}
 # add edge weights to the network, accounting for the combined effect of the
 # edge length, distance from a give geometry, intersection with a buffer region
-add_weights <- function(net, geom, buffer){
+add_weights <- function(net, geom, buffer = NULL) {
     edges <- net |> st_as_sf("edges")
     distances <- st_distance(edges, geom, which = "Euclidean")
     # the following is very slow, use approximate (faster) approach
     # is_inside <- edges |>
         # st_covered_by(buffer, sparse = FALSE)
-    is_inside <- edges |>
-        st_centroid() |>
-        st_intersects(buffer, sparse = FALSE)
+    if (!is.null(buffer)) {
+        is_inside <- edges |>
+            st_centroid() |>
+            st_intersects(buffer, sparse = FALSE) |> 
+            as.numeric()
+        repellance <- set_units(1000., m) * is_inside
+    } else{
+        repellance <- set_units(0, m)
+    }
+    
     # convert this to numeric values, and assign it a fictitious
     # unit in order to be able to combine it with the other commpondents
     # of the weight
-    is_inside <- as.numeric(is_inside) |> set_units(m)
     name <- sprintf("weight_%s", names(geom))
     net |>
         activate("edges") |>
-        mutate("{name}" := 1. * edge_length() + 1. * distances + 1000. * is_inside)
+        mutate("{name}" := 1. * edge_length() + 1. * distances + repellance)
 }
 
 network_weights <- network_classified |>
@@ -250,12 +256,36 @@ leaflet() |>
     addPolylines(data = corridor_edge_2 |> get_geom_latlon(), color = "green", weight = 10)
 ```
 
+### Fix deviations
+
+```{r}
+corridor_edge_1 <- corridor_edge_1 |> st_union()
+corridor_edge_2 <- corridor_edge_2 |> st_union()
+
+names(corridor_edge_1) <- "side_1"
+names(corridor_edge_2) <- "side_2"
+
+network_weights_2 <- network_weights |> 
+    add_weights(corridor_edge_1) |> 
+    add_weights(corridor_edge_2)
+
+network_split_2 <- network_weights_2  |>
+    activate("edges") |>
+    st_filter(waterway, .predicate = not_intersects) |>
+    activate("nodes") |>
+    filter(!node_is_isolated())
+
+corridor_edge_1_nodev <- get_corridor_edge(network_split_2, end_points_side_1,  weight_name = "weight_side_1")
+corridor_edge_2_nodev <- get_corridor_edge(network_split_2, end_points_side_2,  weight_name = "weight_side_2")
+```
+
+
 ### 3.5 Save output
 
 Capping the corridor using the city boundary:
 
 ```{r}
-corridor_edges <- st_union(corridor_edge_1, corridor_edge_2)
+corridor_edges <- st_union(corridor_edge_1_nodev, corridor_edge_2_nodev)
 
 corridor <- city_boundary |>
     st_split(corridor_edges) |>


### PR DESCRIPTION
This fixes the deviations in the previous delineation, following the solution proposed in [#21](https://github.com/CityRiverSpaces/prototyping/issues/21#issuecomment-2416151793)

![image](https://github.com/user-attachments/assets/7c954c1d-6144-4f09-b727-82f9456f6fbc)
