### PR TITLE
Draft riverspace delineation

### DIFF
--- a/notebooks/riverspace/riverspace_bucharest-download-OSM-data.qmd
+++ b/notebooks/riverspace/riverspace_bucharest-download-OSM-data.qmd
@@ -1,0 +1,118 @@
+---
+title: "Download OSM data for riverspace delineation"
+format: html
+---
+
+```{r}
+#| label: setup
+#| message: false
+
+library("dplyr")
+library("here")
+library("leaflet")
+library("osmdata")
+library("sf")
+```
+
+In this notebooks we download the relevant OSM data for the riverspace delineation of River Dâmbovița, Bucharest. We get the data for the bounding box enclosing the delineated river corridor
+
+```{r}
+river_name <- "Dâmbovița"
+epsg_code <- 32635  # UTM zone 35N
+bbox_buffer <- 2000  # in m, expand bbox for street network
+
+# define the directory where to store the output
+output_dir = here("data/generated")
+```
+
+We define a couple of utility functions:
+
+```{r}
+# query the Overpass API for a key:value pair within a given bounding box
+osmdata_as_sf <- function(key, value, bbox){
+  bbox |>
+    opq() |>
+    add_osm_feature(key = key, value = value) |>
+    osmdata_sf()
+}
+
+# get geometry in lat/lon (WGS84)
+get_geom_latlon <- function(x) st_transform(x, 4326) |> st_geometry()
+```
+
+We start by getting the bounding box of the corridor:
+
+```{r}
+corridor <- st_read(here("data/generated/corridor.gpkg")) |> st_transform(4326)
+bbox <- st_bbox(corridor)
+```
+
+## 1. Waterways ---
+
+Querying the Overpass API for `waterway:river`. OSM multilines include river lines grouped by the river name. We extract the relevant waterway and transform to the projected CRS:
+
+```{r}
+# waterways (linestrings)
+waterways <- osmdata_as_sf("waterway", "river", bbox)
+waterway <- waterways$osm_multilines |>
+    filter(name == river_name) |>
+    st_transform(epsg_code) |>
+    st_geometry()
+```
+
+We also query the Overpass API for `natural:water`. The results also include features such as fountains. The geometries are not contiguous and some part of the water bodies are actually represented as lines instead of polygons. We determine and keep the only features that intersect the relevant waterway:
+
+```{r}
+# water area (polygons)
+water <- osmdata_as_sf("natural", "water", bbox)
+waterbody <- bind_rows(water$osm_polygons, water$osm_multipolygons) |>
+    st_transform(epsg_code) |>
+    st_filter(waterway, .predicate = st_intersects) |>
+    st_union() |>
+    st_geometry()
+```
+
+```{r}
+# save the waterway and water body geometries
+st_write(
+    c(waterway, waterbody),
+    dsn = sprintf("%s/waterway_%s.gpkg", output_dir, river_name),
+    append = FALSE,
+    quiet = TRUE,
+)
+```
+
+## 2. Buildings ----
+
+Querying the Overpass API for the `building` key, using the expanded bounding box to include relevant buildings close to the edge of the city:
+
+```{r}
+buildings <- osmdata_as_sf("building", NULL, bbox)
+buildings_dambovita <- buildings$osm_polygons |>
+    st_transform(epsg_code) |> 
+    st_filter(st_buffer(waterbody, 500), .predicate = st_intersects) |>
+    st_geometry() 
+```
+
+```{r}
+# save the street geometries
+st_write(
+    buildings_dambovita,
+    dsn = sprintf("%s/buildings_%s.gpkg", output_dir, river_name),
+    append = FALSE,
+    quiet = TRUE,
+)
+```
+
+## 3. Visualize OSM data ----
+
+```{r}
+leaflet() |>
+    addTiles() |>
+    # addPolylines(data = city_boundary |> get_geom_latlon(), color = "yellow", group = "city") |>
+    # addPolylines(data = waterway |> get_geom_latlon(), color = "blue", group = "water") |>
+    # addPolygons(data = waterbody |> get_geom_latlon(), color = "cyan", group = "water") |>
+    addPolylines(data = buildings_dambovita |> get_geom_latlon(), color = "black", group = "highways")
+    # addPolylines(data = railways_lines |> get_geom_latlon(), color = "red", group = "railways") |>
+    # addLayersControl(overlayGroups = c("city", "water", "highways", "railways"))
+```

--- a/notebooks/riverspace/riverspace_bucharest.qmd
+++ b/notebooks/riverspace/riverspace_bucharest.qmd
@@ -1,0 +1,184 @@
+---
+title: "River space delineation"
+format: html
+---
+
+```{r}
+#| label: setup
+#| message: false
+
+library("dplyr")
+library("here")
+library("leaflet")
+library("lwgeom")
+library("sf")
+
+data_dir <- here("data/generated")
+```
+
+In this notebook we explore how to delineate a river space using River Dâmbovița in Bucharest as the study area:
+
+```{r}
+river_name <- "Dâmbovița"
+```
+
+We define a utility function for visualization:
+
+```{r}
+# get geometry in lat/lon (WGS84)
+get_geom_latlon <- function(x) st_transform(x, 4326) |> st_geometry()
+```
+
+
+
+## 1. Input data ----
+
+We load the OSM data that we have previously downloaded (see notebook [`download-OSM-data_bucharest.qmd`](./download-OSM-data_bucharest.qmd)):
+
+```{r}
+load_data <- function(dir, handle, name) {
+    file_name <- sprintf("%s/%s_%s.gpkg", dir, handle, name)
+    st_read(file_name, quiet = TRUE)
+}
+
+water <- load_data(data_dir, "waterway", river_name)
+waterbody <- water[2,] |> st_geometry()
+
+wateredges <- waterbody |> 
+    st_cast("MULTILINESTRING") |> 
+    st_cast("LINESTRING") |> 
+    st_sfc()
+```
+
+We generate viewpoints from the river edges:
+
+```{r}
+#| label: viewpoints
+viewpoints <- st_line_sample(wateredges, density = 1/50) |> st_cast("POINT")
+```
+
+We also load the buildings:
+
+```{r}
+buildings <- load_data(data_dir, "buildings", river_name) |> st_geometry()
+```
+
+Visualize input data:
+
+```{r}
+leaflet() |>
+    addTiles() |>
+    addPolylines(data = wateredges |> get_geom_latlon(), color = "cyan") |>
+    addCircles(data = viewpoints |> get_geom_latlon(), radius = 1, color = "red") |>
+    addPolylines(data = buildings |> get_geom_latlon(), color = "black")
+```
+
+## 2. River space delineation ----
+
+```{r}
+#| label: isovist
+
+st_isovist <- function(buildings, 
+                       viewpoint, 
+                       # default, a ray every 5 degrees
+                       rayno = 41,     
+                       # default, 100 meters
+                       raydist = 100) {
+
+  
+  maxisovist <- st_buffer(viewpoint, dist = raydist, nQuadSegs = (rayno-1)/4)
+  rayvertices <- st_cast(maxisovist,"POINT")
+
+  buildintersections <- st_intersects(buildings, maxisovist, sparse = FALSE)
+
+  if (!TRUE %in% buildintersections){
+    isovist <- maxisovist
+  } else {
+    rays <- lapply(X = 1:length(rayvertices), 
+                   FUN = \(x) {
+                       pair <- st_combine(c(rayvertices[x],viewpoint))
+                       line <- st_cast(pair, "LINESTRING")
+                       return(line)})
+    rays <- do.call(c, rays)
+    rays <- st_sf(geometry = rays,
+                  id = 1:length(rays))
+    
+    buildsinmaxisovist <- buildings[buildintersections] |> st_union()
+    raysoutsidebuilding <- st_difference(rays, buildsinmaxisovist)
+    
+    # get each ray segment closest to viewpoint
+    multilines <- dplyr::filter(raysoutsidebuilding, st_is(geometry, c("MULTILINESTRING")))
+    multilines_points <- multilines |> st_cast("MULTIPOINT") |> st_cast("POINT")
+    
+    singlelines <- dplyr::filter(raysoutsidebuilding, st_is(geometry, c("LINESTRING")))
+    singlelines_points <- singlelines |> st_cast("POINT")
+    
+    # get furthest vertex of ray segment closest to view point
+    singlelines_end <- singlelines_points  |>  
+      group_by(id) |> 
+      dplyr::slice_tail(n = 2) |>
+      dplyr::slice_head(n = 1) |>
+      summarise(do_union = FALSE, .groups = 'drop') |>
+      st_cast("POINT")
+    
+    multilines_end  <- multilines_points |> 
+      group_by(id) |>
+      dplyr::slice_tail(n = 2) |>
+      dplyr::slice_head(n = 1) |>
+      summarise(do_union = FALSE, .groups = 'drop') |>
+      st_cast("POINT")
+    
+    # Combining vertices, ordering clockwise by ray angle and casting to polygon
+    alllines <- rbind(singlelines_end, multilines_end)
+    alllines <- alllines[order(alllines$id),] 
+    isovist  <- st_cast(st_combine(alllines),"POLYGON")
+  }
+  isovist
+}
+```
+
+```{r}
+isovists <- lapply(X = 1:length(viewpoints), FUN = \(x) {
+  viewpoint <- viewpoints[x]
+  st_isovist(buildings = buildings,
+             viewpoint = viewpoint,
+             rayno = 41,
+             raydist = 100) |> suppressWarnings()
+})
+```
+
+```{r}
+intersecting_buildings <- 
+    buildings[st_intersects(buildings, allisovists, sparse = FALSE)] |> st_union()
+allisovists <- do.call(c, isovists) |> 
+    st_union() |> 
+    st_difference(intersecting_buildings)
+```
+
+Visualize delineated river space:
+
+```{r}
+leaflet() |>
+    addTiles() |>
+    addPolylines(data = buildings |> get_geom_latlon(), color = "black") |>
+    addPolylines(data = intersecting_buildings |> get_geom_latlon(), color = "purple") |>
+    addPolylines(data = wateredges |> get_geom_latlon(), color = "cyan") |>
+    addCircles(data = viewpoints |> get_geom_latlon(), radius = 1, color = "green") |>
+    addPolylines(data = allisovists |> get_geom_latlon(), color = "red")
+```
+
+
+
+## 3. Saving the output ----
+
+Save output to disk:
+
+```{r}
+file_name <- sprintf("%s/riverspace_%s.gpkg", data_dir, river_name)
+st_write(
+    allisovists,
+    dsn = file_name,
+    append = FALSE,
+    quiet = TRUE,
+)
+```

--- a/notebooks/riverspace/riverspace_bucharest.qmd
+++ b/notebooks/riverspace/riverspace_bucharest.qmd
@@ -148,11 +148,12 @@ isovists <- lapply(X = 1:length(viewpoints), FUN = \(x) {
 ```
 
 ```{r}
-intersecting_buildings <- 
-    buildings[st_intersects(buildings, allisovists, sparse = FALSE)] |> st_union()
 allisovists <- do.call(c, isovists) |> 
-    st_union() |> 
-    st_difference(intersecting_buildings)
+    st_union() 
+intersecting_buildings <- 
+    buildings[st_intersects(buildings, allisovists, sparse = FALSE)] |> 
+    st_union()
+allisovists <- st_difference(allisovists, intersecting_buildings)
 ```
 
 Visualize delineated river space:


### PR DESCRIPTION
@fnattino I drafted the riverspace delineation starting from [this approach](https://rpubs.com/richardneilbelcher/isovist). As an additional step, I subtracted the first line of buildings form ther resulting isovist. This creates a more accurate first line:

![image](https://github.com/user-attachments/assets/727a93be-c971-425d-8714-77d0e576e9fc)

However, it does not solve some less accurate boundary details, both in the back and in the front of buildings:

![image](https://github.com/user-attachments/assets/2715327a-c1d0-4b91-a160-b43e65773322)

![image](https://github.com/user-attachments/assets/b100559b-565a-4175-ae88-0c11ddcdee58)

Whenever the river is underground, the river centreline could be used as a fallback option for viewpoints:

![image](https://github.com/user-attachments/assets/7aa325cd-fc6f-49db-b24e-8be58da297e9)

The overall delineation is ready for review. If you agree, we can fix the above details within the CRiSp repo.
